### PR TITLE
fix "proceeding" spelling

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -224,7 +224,7 @@
 	},
 	"terms_and_conditions": {
 		"title": "Terms and Conditions",
-		"description": "By proceding, you agree to these ",
+		"description": "By proceeding, you agree to these ",
 		"terms": "Terms and Conditions"
 	},
 	"privacy_policy": {


### PR DESCRIPTION
Fixes the spelling of "proceeding" from "proceding" in Terms and Conditions.

